### PR TITLE
Stop the snapshot store getting permanently poisoned by unpatched restart artifacts (v0.9.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,58 @@
 
 All notable changes. Loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.9.5] — 2026-08-17
+### Fixed
+- **The snapshot store could get permanently poisoned with a restart
+  artifact, causing `last_changed` to stay wrong across every subsequent
+  restart.** Every HA restart resets `last_changed` to the restart moment
+  for all entities before this integration gets a chance to correct it. If
+  `_resolve()` couldn't find/apply a real timestamp for a given candidate
+  during some boot pass — for any reason (a recorder race, a legitimate
+  "just changed, too recent" decline, or anything else) — that entity's
+  live `last_changed` stayed at the raw, uncorrected restart-reset value
+  for the rest of that session. The periodic snapshot timer and the
+  clean-shutdown snapshot write both read `live.last_changed` straight off
+  the state machine with no way to tell a confirmed real value from an
+  unconfirmed artifact, so that uncorrected value got written into the
+  persistent snapshot store as if it were genuine.
+
+  From that point on the wrong value was self-reinforcing: on every future
+  boot, `_resolve()`'s snapshot check (step 2, checked before the deep/
+  best-effort steps that would find the real answer) saw the entity still
+  holding the same value, and the poisoned timestamp was — by definition —
+  older than the *new* restart's fresh cutoff, so it comfortably cleared
+  the margin check and got confidently reapplied. This happened silently,
+  every single boot, without ever reaching the recorder-query steps that
+  would have found the true value, and it was completely independent of
+  (and unaffected by) the 0.9.3 purge-boundary fix, which only touches the
+  best-effort unbounded step, not the snapshot short-circuit ahead of it.
+
+  Field-diagnosed on the same real installation as 0.9.3: after upgrading,
+  a `verify` pass still reported ~1,600 mismatches, barely down from the
+  pre-0.9.3 count. Direct (read-only) queries against the installation's
+  recorder database confirmed the mechanism precisely: entities' *live*
+  `last_changed` matched one of their own earlier restart's own artifact
+  rows still sitting in the database, while `verify`'s freshly recomputed
+  answer matched the oldest surviving row for that entity exactly to the
+  microsecond — and the installation's own `.storage/last_changed_keeper.snapshot`
+  held that same wrong, restart-artifact timestamp for the affected
+  entities.
+
+  `_resolve()` no longer accepts blame for this: entities whose live
+  `last_changed` is still an unconfirmed restart artifact are now tracked
+  (`_unconfirmed`, cleared on any successful patch or genuine value change),
+  and both snapshot write paths preserve an unconfirmed entity's *existing*
+  stored entry (or leave it unwritten if there isn't one) instead of
+  overwriting it with the unverified live value.
+
+  **This does not retroactively fix an already-poisoned snapshot** — the
+  fix only stops *new* poisoning. If you're upgrading from an affected
+  version, clear `.storage/last_changed_keeper.snapshot` once (with Home
+  Assistant stopped) to let it rebuild cleanly through the now-safe resolve
+  chain; leaving it in place means already-wrong entities stay wrong until
+  their value genuinely changes for real.
+
 ## [0.9.4] — 2026-08-17
 ### Fixed
 - **Unbounded rows per entity in the bulk pass — the remaining OOM driver

--- a/custom_components/last_changed_keeper/__init__.py
+++ b/custom_components/last_changed_keeper/__init__.py
@@ -315,6 +315,12 @@ class _RestoreJob:
         self._final_fired = False
         self.stats: dict[str, object] = {}
 
+        # Entities whose live last_changed is still an unconfirmed restart
+        # artifact (a candidate this session that _resolve() has not yet
+        # been able to patch) — see async_write_snapshot, which must not
+        # persist these into the snapshot store as if they were real.
+        self._unconfirmed: set[str] = set()
+
         # ----- Feature: rolling run history + boot self-check --------------
         # runs_store is None in direct unit-test construction; persistence is
         # then simply skipped (run_history stays in-memory only).
@@ -486,6 +492,17 @@ class _RestoreJob:
         boot (see _resolve) — otherwise it could stamp the *previous* value's
         last_changed onto a genuinely new value.
 
+        For an entity still in _unconfirmed (a restart candidate this
+        session that _resolve() has never managed to patch), live.last_changed
+        is itself just this restart's raw reset value, not a real timestamp —
+        writing it here would poison the snapshot with that artifact, and
+        _resolve's step 2 would then confidently reapply it on every future
+        boot (comfortably clearing the margin check against each new restart's
+        fresher cutoff) without ever reaching the deep/best-effort steps that
+        would find the real answer. So an unconfirmed entity's *existing*
+        stored entry (if any) is carried forward unchanged instead — no worse
+        than before, and not actively made wrong.
+
         Used both as the EVENT_HOMEASSISTANT_STOP listener (receives an
         Event) and as the periodic snapshot timer (receives a datetime) —
         the argument itself is never used, both just trigger a fresh write.
@@ -494,8 +511,14 @@ class _RestoreJob:
         data: dict[str, dict[str, str]] = {}
         for entity_id in self._targets(domains, entities, exclude, labels, areas):
             live = self.hass.states.get(entity_id)
-            if live is not None and live.state not in INVALID_STATES:
-                data[entity_id] = {"s": live.state, "t": live.last_changed.isoformat()}
+            if live is None or live.state in INVALID_STATES:
+                continue
+            if entity_id in self._unconfirmed:
+                prior = self._snapshot.get(entity_id)
+                if prior is not None:
+                    data[entity_id] = prior
+                continue
+            data[entity_id] = {"s": live.state, "t": live.last_changed.isoformat()}
         await self._store.async_save(data)
         # Keep the in-memory copy in sync with what's on disk: this is also
         # what naturally bounds the incremental store's size (see
@@ -554,6 +577,7 @@ class _RestoreJob:
             live = self.hass.states.get(entity_id)
             if live is None or live.state in INVALID_STATES:
                 self._pending.add(entity_id)
+                self._unconfirmed.add(entity_id)
                 continue
             if (dt_util.utcnow() - live.last_changed).total_seconds() > grace:
                 continue  # already really used since boot
@@ -593,15 +617,25 @@ class _RestoreJob:
                 live = self.hass.states.get(entity_id)
                 if live is None or live.state in INVALID_STATES:
                     self._pending.add(entity_id)
+                    self._unconfirmed.add(entity_id)
                     continue
                 if live.last_changed != candidate_last_changed[entity_id]:
-                    continue  # changed for real while we were awaiting the query
+                    # Changed for real while we were awaiting the query — this
+                    # last_changed reflects genuine usage, not an artifact.
+                    self._unconfirmed.discard(entity_id)
+                    continue
                 if await self._maybe_restore_last_triggered(entity_id):
                     patched_triggered += 1
                 ts = await self._resolve(entity_id, live, bulk.get(entity_id), counters)
                 if ts is not None:
                     self._apply(live, ts, entity_id)
                     patched += 1
+                else:
+                    # _resolve couldn't confirm anything: live.last_changed is
+                    # still this restart's raw reset value. Tracked so
+                    # async_write_snapshot doesn't persist it as if it were
+                    # real (see _unconfirmed).
+                    self._unconfirmed.add(entity_id)
             del bulk  # released before the next batch is fetched
 
         # Resolve a stale repair issue once the cache patch works again
@@ -1014,6 +1048,7 @@ class _RestoreJob:
     # ----- Applying ------------------------------------------------------
 
     def _apply(self, live: State, ts: datetime, entity_id: str) -> None:
+        self._unconfirmed.discard(entity_id)
         ok = _apply_last_changed(live, ts, self._also_updated)
         if not ok and not self._degraded:
             self._degraded = True
@@ -1163,6 +1198,9 @@ class _RestoreJob:
         await self._maybe_restore_last_triggered(entity_id)
         ts = await self._resolve(entity_id, live, None)
         if ts is None:
+            # Unresolved: live.last_changed is still this re-registration's
+            # raw reset value — see _unconfirmed.
+            self._unconfirmed.add(entity_id)
             return _RETRY_WORTHWHILE
         self._apply(live, ts, entity_id)
         _LOGGER.debug("%s: re-patched after runtime re-registration", entity_id)
@@ -1245,6 +1283,7 @@ class _RestoreJob:
             return
         if new.state in INVALID_STATES or old.state == new.state:
             return
+        self._unconfirmed.discard(new.entity_id)
         self._dirty[new.entity_id] = {
             "s": new.state,
             "t": new.last_changed.isoformat(),

--- a/custom_components/last_changed_keeper/manifest.json
+++ b/custom_components/last_changed_keeper/manifest.json
@@ -11,5 +11,5 @@
   "loggers": ["custom_components.last_changed_keeper"],
   "quality_scale": "gold",
   "single_config_entry": true,
-  "version": "0.9.4"
+  "version": "0.9.5"
 }

--- a/tests/test_incremental_store.py
+++ b/tests/test_incremental_store.py
@@ -233,6 +233,63 @@ async def test_resolve_prefers_newer_store_value_over_bulk_when_bounded(
     assert result == newer_store_ts
 
 
+
+# ----- async_write_snapshot(): must not poison the store with an --------
+# ----- unconfirmed restart artifact (see _unconfirmed in __init__.py) ---
+
+
+async def test_snapshot_write_preserves_prior_entry_for_unconfirmed_entity(
+    recorder_mock, hass: HomeAssistant
+) -> None:
+    """An entity still in _unconfirmed (a boot candidate _resolve() never
+    managed to patch) must not have its raw, unresolved live.last_changed
+    overwrite whatever the store already held for it - that would poison
+    the store with a restart artifact, which _resolve()'s snapshot step
+    would then confidently reapply on every future boot."""
+    hass.states.async_set("light.kitchen", "on")
+    good_ts = dt_util.utcnow() - timedelta(days=3)
+    job = _make_job(
+        hass, snapshot={"light.kitchen": {"s": "on", "t": good_ts.isoformat()}}
+    )
+    job._unconfirmed.add("light.kitchen")
+
+    await job.async_write_snapshot()
+
+    assert job._snapshot["light.kitchen"] == {"s": "on", "t": good_ts.isoformat()}
+
+
+async def test_snapshot_write_omits_unconfirmed_entity_with_no_prior_entry(
+    recorder_mock, hass: HomeAssistant
+) -> None:
+    """Same as above, but with nothing previously stored - there is no
+    better answer to fall back to, so the entity is simply left out rather
+    than seeded with an unresolved value."""
+    hass.states.async_set("light.kitchen", "on")
+    job = _make_job(hass)
+    job._unconfirmed.add("light.kitchen")
+
+    await job.async_write_snapshot()
+
+    assert "light.kitchen" not in job._snapshot
+
+
+async def test_snapshot_write_uses_live_value_for_confirmed_entity(
+    recorder_mock, hass: HomeAssistant
+) -> None:
+    """Control case: an entity not in _unconfirmed is written from its
+    current live state as before."""
+    hass.states.async_set("light.kitchen", "on")
+    live = hass.states.get("light.kitchen")
+    job = _make_job(hass)
+
+    await job.async_write_snapshot()
+
+    assert job._snapshot["light.kitchen"] == {
+        "s": "on",
+        "t": live.last_changed.isoformat(),
+    }
+
+
 async def test_resolve_ignores_older_store_value_when_bulk_bounded(
     recorder_mock, hass: HomeAssistant
 ) -> None:

--- a/tests/test_periodic_snapshot.py
+++ b/tests/test_periodic_snapshot.py
@@ -40,11 +40,48 @@ async def test_periodic_snapshot_writes_on_interval(
 
     assert STORAGE_KEY not in hass_storage
 
+    # A genuine value change confirms the entity (see _unconfirmed in
+    # __init__.py) so the periodic write is free to persist it — a fresh
+    # boot candidate with no recorder history never gets confirmed, and
+    # asserting on one here would just be re-testing the poisoning bug
+    # fixed by test_periodic_snapshot_does_not_poison_unconfirmed_entity
+    # below.
+    hass.states.async_set("light.kitchen", "off")
+    await hass.async_block_till_done()
+
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=310))
     await hass.async_block_till_done()
 
     assert STORAGE_KEY in hass_storage
     assert "light.kitchen" in hass_storage[STORAGE_KEY]["data"]
+
+
+async def test_periodic_snapshot_does_not_poison_unconfirmed_entity(
+    recorder_mock, enable_custom_integrations, hass: HomeAssistant, hass_storage
+) -> None:
+    """Regression: a fresh boot candidate with no recorder history that
+    _resolve() never manages to patch must not have its raw restart-reset
+    last_changed written into the snapshot store by the periodic timer —
+    that value would then be wrongly trusted as real on every future boot
+    (see the _unconfirmed docstring on async_write_snapshot)."""
+    hass.states.async_set("light.kitchen", "on")
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_DOMAINS: ["light"],
+            CONF_ENTITIES: [],
+            CONF_SNAPSHOT_INTERVAL: 300,
+        },
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=310))
+    await hass.async_block_till_done()
+
+    assert STORAGE_KEY in hass_storage
+    assert "light.kitchen" not in hass_storage[STORAGE_KEY]["data"]
 
 
 async def test_snapshot_interval_zero_disables_periodic_write(


### PR DESCRIPTION
## Summary

Follow-up to the 0.9.3 purge-boundary fix. After upgrading to 0.9.4 (thanks
for that one — the bulk-query rewrite is a real improvement), `verify` on
the same ~3,500-entity installation this was all diagnosed against still
reported ~1,600 mismatches, barely down from the pre-0.9.3 baseline. That
turned out to be a second, unrelated bug: the snapshot store can get
permanently poisoned with a restart artifact, and once poisoned, an
entity's `last_changed` stays wrong across every subsequent restart
indefinitely — completely independent of (and unaffected by) either the
purge-boundary fix or the 0.9.4 bulk-query rewrite.

## Root cause

Every HA restart resets an entity's live `last_changed` to the restart
moment before this integration gets a chance to correct it (the entire
reason it exists). If `_resolve()` ever failed to find/apply a real
timestamp for a candidate during some boot pass — for *any* reason (a
recorder race, a legitimate "just changed, too recent" decline, or
anything else) — that entity's live `last_changed` simply stayed at the
raw, uncorrected restart-reset value for the rest of that session.

Both `async_write_snapshot` call sites (the periodic timer and the
clean-shutdown write) read `live.last_changed` straight off the state
machine with no way to distinguish a confirmed real timestamp from an
unconfirmed artifact — so that uncorrected value got persisted into the
snapshot store as if it were genuine.

From there the wrong value became self-reinforcing. On every future boot,
`_resolve()`'s snapshot check (step 2, checked *before* the deep/
best-effort steps that would find the real answer) sees the entity still
holding the same value, and the poisoned timestamp is — by definition —
older than the *new* restart's fresh cutoff, so it comfortably clears the
margin check and gets confidently reapplied. This happens silently, every
single boot, without the pass ever reaching the recorder-query steps that
would find the true value.

## How this was diagnosed

Two unrelated entities (an `input_boolean` helper and an `automation`
entity — chosen to rule out any integration-specific polling behavior,
since helpers have none) each showed unbroken same-value history since
their oldest surviving recorder row — no genuine change anywhere in the
retained data. `verify`'s `expected` matched that oldest row to the
microsecond; `live_last_changed` matched one of the entity's *own* earlier
restart-artifact rows still in the database — and the installation's own
`.storage/last_changed_keeper.snapshot` held that same wrong timestamp,
confirming the poisoned-snapshot short-circuit directly.

## Fix

Adds `self._unconfirmed`, a set of entity IDs whose live `last_changed` is
currently just an unconfirmed restart/re-registration artifact:
- Added when a boot candidate's `_resolve()` returns nothing, when an
  entity is unavailable at boot start, or when a re-registration retry
  attempt resolves nothing.
- Cleared by `_apply()` on any successful patch (boot, pending retry, or
  re-registration — all funnel through this one method), and by the
  incremental listener on any genuine value change (unambiguous ground
  truth regardless of what came before).

Both `async_write_snapshot` call sites now skip entities still in
`_unconfirmed`, preserving whatever entry (if any) is already stored for
them instead of overwriting it with the unverified live value.

## Trade-off / upgrade note

**This does not retroactively fix an already-poisoned snapshot** — the fix
only stops *new* poisoning going forward. On an installation already
affected, clear `.storage/last_changed_keeper.snapshot` once (with HA
stopped) after upgrading, so it rebuilds cleanly through the now-safe
resolve chain. Leaving the old file in place means already-wrong entities
stay wrong until their value genuinely changes for real.

## Test plan

- [x] `pytest -q` — 137 passed (4 new snapshot-poisoning tests)
- [x] `ruff check .` — all checks passed

Full history/investigation at
[cerebrate/last_changed_keeper#6](https://github.com/cerebrate/last_changed_keeper/pull/6).