### PR TITLE
Bound listener/burst-drain concurrency and pace the bulk-query stream (v0.9.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,121 @@
 
 All notable changes. Loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.9.6] — 2026-08-18
+### Changed
+- **`_patch_all_pending` (the scheduled/manual retry sweep of `self._pending`)
+  now re-checks each entity's pending membership immediately before
+  querying it, instead of only once when the sweep's snapshot was taken.**
+  A scheduled retry pass and the boot-pending recovery burst's drain (see
+  below) are both coroutines that yield control at their own await points,
+  so they can run concurrently: without the re-check, a retry pass working
+  through its snapshot could still call into an entity the drain had
+  already resolved and discarded moments earlier, issuing a wasted
+  redundant recorder query for it. Existing margin/bounded-run checks in
+  `_resolve()` already prevented this from producing a *wrong* value, but
+  the redundant work was needless recorder load that grows with how often
+  the two paths overlap.
+
+- **The boot-pending recovery listener (entities still unavailable/unknown
+  when the boot pass ran) now coalesces unavailable→real transitions into a
+  single batched drain, the same treatment already given to the
+  re-registration listener above.** Previously, every transition
+  immediately spawned its own task issuing its own targeted, per-entity
+  recorder query (`_patch_pending`, always querying without bulk data). A
+  mass recovery early in boot — a Zigbee/Z-Wave mesh finishing formation and
+  announcing many devices within the same few seconds — fired one recorder
+  query per entity all at once, and each of those queries used the raw,
+  undeduplicated deep query rather than the recorder's genuine-value-change
+  bulk query, the same correctness gap fixed for re-registrations above.
+
+  Transitions are now debounce-coalesced (`PENDING_RECOVERY_DEBOUNCE_SECONDS`,
+  capped by `PENDING_RECOVERY_MAX_WAIT_SECONDS`) into a burst set, then
+  drained together via `_drain_pending_recovery_burst`, which reuses the
+  boot pass's streaming bulk-query machinery (`_iter_bulk_batches`). Unlike
+  the re-registration burst there's no separate per-entity retry ladder
+  here: an entity the drain can't resolve simply stays in `_pending`, same
+  as it always has, for the existing scheduled retry passes
+  (`_schedule_retries` / `_patch_all_pending`) to pick up later.
+
+- **The streamed bulk recorder query (`_iter_bulk_batches`, shared by the
+  boot pass, `verify`, and the re-registration/pending-recovery burst
+  drains) now paces itself with a zero-delay `asyncio.sleep(0)` after each
+  batch.** A large "track all entities" install can mean many batches back
+  to back, each a synchronous query on the recorder's own single-worker
+  executor; without a yield point between them, the pass's own coroutine
+  was immediately ready again the instant one batch resolved, which could
+  crowd out other ready callbacks on the main event loop for the whole
+  pass. `sleep(0)` is a pure yield with no added delay — pacing this way
+  costs nothing in wall-clock time, it only gives other already-ready work
+  a fair turn between batches.
+
+- **Runtime re-registrations (a config entry reload, a Zigbee/Z-Wave device
+  or coordinator rejoining) are now coalesced into a single batched drain
+  instead of firing one recorder query per entity.** Previously, every
+  re-registration event immediately spawned its own task, and each task ran
+  its own targeted, per-entity recorder query
+  (`_attempt_reregister_patch`). A mass re-registration — a hub's config
+  entry reloading with hundreds of entities at once, or a coordinator
+  reconnecting after an outage and re-registering everything it owns —
+  therefore fired hundreds of concurrent tasks, each issuing its own
+  recorder query: a thundering herd on the recorder executor with no
+  batching at all, unlike the boot pass (which has used a streamed bulk
+  query since 0.9.4).
+
+  Re-registrations are now debounce-coalesced (`REREGISTER_DEBOUNCE_SECONDS`,
+  capped by `REREGISTER_MAX_WAIT_SECONDS` for a continuously-arriving burst,
+  the same debounce/max-wait shape already used for the incremental
+  store) into a burst set, then drained together via
+  `_drain_reregister_burst` — which reuses the boot pass's streaming bulk
+  query machinery (`_iter_bulk_batches`) instead of querying one entity at a
+  time. A mass re-registration now costs a handful of batched queries
+  (bounded by `bulk_batch_size`) instead of one query per entity.
+
+  Entities that don't resolve from the batched drain still get the same
+  per-entity retry ladder as before (`retry_delays`) — retries are already
+  spread out in time and aren't the source of the thundering-herd risk, so
+  that path is unchanged. A single, isolated re-registration (the common
+  case) still resolves quickly; it just now waits out the short debounce
+  window first rather than being patched on the very next event loop tick.
+
+### Fixed
+- **An entity recovering from `unavailable`/`unknown` to a real value during
+  normal runtime (not a restart, not a full re-registration) reset
+  `last_changed` the same way a restart does, but nothing ever corrected it
+  back.** HA's own state machine treats `unavailable`/`unknown` as a
+  distinct value, so a brief network blip, Zigbee/Z-Wave mesh hiccup, or
+  coordinator reconnect that took a device briefly offline and back
+  genuinely bumped its `last_changed` to the recovery moment — even though,
+  from this integration's point of view, that's exactly the same kind of
+  artifact a restart produces. Unlike a restart, nothing previously
+  re-examined that entity afterwards: the boot pass only runs once at
+  startup, and the re-registration listener only fired when an entity was
+  fully re-created (`old_state is None`), not when it merely recovered from
+  an invalid state. Left uncorrected, an entity that flaps `unavailable`
+  periodically — common for exactly this class of device — drifted wrong
+  forever, self-healing only at the next full HA restart.
+
+  Field-diagnosed on the same real installation as 0.9.3/0.9.5: a fresh
+  `verify` pass reported 811 mismatches out of 3,450 checked entities.
+  Cross-referencing each mismatch against the recorder database (read-only)
+  showed 734 of the 811 (90.5%, spread across 16 different domains) were
+  immediately preceded by an `unavailable`/`unknown` row — not a boot reset,
+  not a full re-registration.
+
+  The re-registration listener now also fires on recovery from
+  `unavailable`/`unknown` (`old_state.state in INVALID_STATES`), routing it
+  through the same debounced batched drain as re-registrations. The
+  incremental store listener (`_on_target_state_changed`) now excludes this
+  same transition from its debounce merge — it was previously treating a
+  recovery-from-unavailable exactly like a genuine value change, which would
+  have written the raw reset artifact into the snapshot store as if it were
+  real, poisoning it for the next boot even after the live value was
+  corrected. An entity is now marked `_unconfirmed` the moment it's queued
+  for the drain (not just after a failed attempt), closing a narrow race
+  where a snapshot write during the debounce window could persist the reset
+  artifact before the drain had a chance to correct it.
+
+
 ## [0.9.5] — 2026-08-17
 ### Fixed
 - **The snapshot store could get permanently poisoned with a restart

--- a/custom_components/last_changed_keeper/__init__.py
+++ b/custom_components/last_changed_keeper/__init__.py
@@ -21,9 +21,15 @@ attribute restored through a separate path (see _maybe_restore_last_triggered)
 and its own apply mechanism.
 
 Entities that get fully re-registered at runtime (a config entry reload, a
-Zigbee/Z-Wave device rejoining) are caught the same way a restart is, via a
-persistent listener (see _setup_reregister_listener) independent of the
-boot-time pending/listener machinery.
+Zigbee/Z-Wave device rejoining) — or that merely recover from
+unavailable/unknown to a real value during normal runtime, e.g. a brief
+network/mesh blip — are caught the same way a restart is, via a persistent
+listener (see _setup_reregister_listener) independent of the boot-time
+pending/listener machinery. Both trigger conditions are debounce-coalesced
+into a single batched drain (see _drain_reregister_burst) so a mass event —
+e.g. a hub's config entry reloading with hundreds of entities at once, or a
+mesh-wide outage recovering — costs a handful of bulk queries instead of
+one recorder query per entity.
 
 Note: setting `last_changed`/`last_triggered` + invalidating the state cache
 uses internal HA structures. All accesses are defensively guarded; if the
@@ -31,6 +37,7 @@ cache access fails, a repair issue is raised instead of crashing.
 """
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import logging
 from collections.abc import AsyncIterator, Iterable
@@ -117,7 +124,11 @@ from .const import (
     LAST_TRIGGERED_DOMAINS,
     MARGIN_SECONDS,
     MAX_RUN_HISTORY,
+    PENDING_RECOVERY_DEBOUNCE_SECONDS,
+    PENDING_RECOVERY_MAX_WAIT_SECONDS,
     PURGE_BOUNDARY_MARGIN_DAYS,
+    REREGISTER_DEBOUNCE_SECONDS,
+    REREGISTER_MAX_WAIT_SECONDS,
     RETRY_DELAYS,
     SERVICE_RESTORE_NOW,
     SERVICE_VERIFY,
@@ -309,6 +320,13 @@ class _RestoreJob:
         self._startup = dt_util.utcnow()
         self._unsub_listener: CALLBACK_TYPE | None = None
         self._unsub_timers: list[CALLBACK_TYPE] = []
+        # Debounce-coalesced burst of pending entities recovering from
+        # unavailable during the boot window, drained together via
+        # _drain_pending_recovery_burst instead of one recorder query per
+        # entity — see _on_pending_entity_recovered.
+        self._pending_recovery_burst: set[str] = set()
+        self._pending_recovery_burst_since: datetime | None = None
+        self._pending_recovery_flush_timer: CALLBACK_TYPE | None = None
         self._degraded = False
         self._also_updated = False
         self._also_restore_triggered = False
@@ -332,6 +350,12 @@ class _RestoreJob:
         # ----- Feature: re-patch on runtime re-registration ---------------
         self._unsub_reregister_listener: CALLBACK_TYPE | None = None
         self._reregister_retry_timers: dict[str, list[CALLBACK_TYPE]] = {}
+        # Debounce-coalesced burst of pending re-registrations, drained
+        # together via _drain_reregister_burst instead of one recorder query
+        # per entity — see _on_entity_reregistered.
+        self._reregister_burst: set[str] = set()
+        self._reregister_burst_since: datetime | None = None
+        self._reregister_flush_timer: CALLBACK_TYPE | None = None
 
         # ----- Feature: incremental runtime store --------------------------
         self._unsub_incremental_listener: CALLBACK_TYPE | None = None
@@ -429,6 +453,9 @@ class _RestoreJob:
         self._stop_boot_machinery()
         self._stop_reregister_listener()
         self._cancel_all_reregister_retries()
+        self._cancel_reregister_flush_timer()
+        self._reregister_burst.clear()
+        self._reregister_burst_since = None
         self._stop_incremental_listener()
         self._cancel_flush_timer()
         self._dirty.clear()
@@ -450,12 +477,21 @@ class _RestoreJob:
         for cancel in self._unsub_timers:
             cancel()
         self._unsub_timers.clear()
+        self._cancel_pending_recovery_flush_timer()
+        self._pending_recovery_burst.clear()
+        self._pending_recovery_burst_since = None
 
     @callback
     def _stop_listener(self) -> None:
         if self._unsub_listener is not None:
             self._unsub_listener()
             self._unsub_listener = None
+
+    @callback
+    def _cancel_pending_recovery_flush_timer(self) -> None:
+        if self._pending_recovery_flush_timer is not None:
+            self._pending_recovery_flush_timer()
+            self._pending_recovery_flush_timer = None
 
     @callback
     def _stop_reregister_listener(self) -> None:
@@ -469,6 +505,12 @@ class _RestoreJob:
             for cancel in timers:
                 cancel()
         self._reregister_retry_timers.clear()
+
+    @callback
+    def _cancel_reregister_flush_timer(self) -> None:
+        if self._reregister_flush_timer is not None:
+            self._reregister_flush_timer()
+            self._reregister_flush_timer = None
 
     @callback
     def _stop_incremental_listener(self) -> None:
@@ -684,7 +726,15 @@ class _RestoreJob:
 
     @callback
     def _setup_listener(self, grace: float) -> None:
-        """Listen for unavailable→real transitions of the pending entities."""
+        """Listen for unavailable→real transitions of the pending entities.
+
+        Individual transitions are debounce-coalesced into a burst set and
+        drained together via _drain_pending_recovery_burst, instead of
+        firing one recorder query per entity — a mass unavailable→real
+        transition early in boot (a Zigbee/Z-Wave mesh finishing formation
+        and announcing many devices within the same few seconds) would
+        otherwise be a thundering herd on the recorder executor.
+        """
 
         @callback
         def _on_change(event: Event) -> None:
@@ -701,11 +751,81 @@ class _RestoreJob:
                 self._pending.discard(entity_id)
                 self._cleanup_if_done()
                 return
-            self.hass.async_create_task(self._patch_pending(entity_id, grace))
+            self._pending_recovery_burst.add(entity_id)
+            now = dt_util.utcnow()
+            if self._pending_recovery_burst_since is None:
+                self._pending_recovery_burst_since = now
+            self._cancel_pending_recovery_flush_timer()
+            elapsed = (now - self._pending_recovery_burst_since).total_seconds()
+            if elapsed >= PENDING_RECOVERY_MAX_WAIT_SECONDS:
+                self._flush_pending_recovery_burst()
+            else:
+                self._pending_recovery_flush_timer = async_call_later(
+                    self.hass,
+                    PENDING_RECOVERY_DEBOUNCE_SECONDS,
+                    self._flush_pending_recovery_burst,
+                )
 
         self._unsub_listener = async_track_state_change_event(
             self.hass, list(self._pending), _on_change
         )
+
+    @callback
+    def _flush_pending_recovery_burst(self, _now: datetime | None = None) -> None:
+        self._cancel_pending_recovery_flush_timer()
+        self._pending_recovery_burst_since = None
+        if not self._pending_recovery_burst:
+            return
+        burst, self._pending_recovery_burst = self._pending_recovery_burst, set()
+        self.hass.async_create_task(self._drain_pending_recovery_burst(burst))
+
+    async def _drain_pending_recovery_burst(self, entity_ids: set[str]) -> None:
+        """Batched replacement for one recorder query per boot-pending
+        entity recovering from unavailable: resolves the whole debounced
+        burst together via the same streaming bulk-query machinery the
+        boot pass uses (_iter_bulk_batches), instead of each firing its own
+        targeted per-entity query (_patch_pending, which — like
+        _attempt_reregister_patch — only ever sees the raw, undeduplicated
+        deep query since it always passes bulk_states=None).
+
+        Entities that don't resolve here are simply left in _pending:
+        unlike the re-registration burst there is no separate per-entity
+        retry ladder to arm here — the existing scheduled retry passes
+        (_schedule_retries / _patch_all_pending) already re-sweep the whole
+        remaining pending set.
+        """
+        candidates: list[str] = []
+        candidate_last_changed: dict[str, datetime] = {}
+        for entity_id in entity_ids:
+            if entity_id not in self._pending:
+                continue  # already resolved by a scheduled retry pass meanwhile
+            live = self.hass.states.get(entity_id)
+            if live is None or live.state in INVALID_STATES:
+                continue
+            candidates.append(entity_id)
+            candidate_last_changed[entity_id] = live.last_changed
+
+        async for chunk, bulk in self._iter_bulk_batches(candidates):
+            for entity_id in chunk:
+                # Re-validate against the snapshot taken above: the bulk
+                # query just awaited the recorder executor, during which the
+                # entity may have gone unavailable again, genuinely changed,
+                # or already been resolved by a scheduled retry pass — see
+                # the matching comment in _async_run_impl.
+                if entity_id not in self._pending:
+                    continue
+                live = self.hass.states.get(entity_id)
+                if live is None or live.state in INVALID_STATES:
+                    continue
+                if live.last_changed != candidate_last_changed[entity_id]:
+                    continue
+                await self._maybe_restore_last_triggered(entity_id)
+                ts = await self._resolve(entity_id, live, bulk.get(entity_id))
+                if ts is not None:
+                    self._apply(live, ts, entity_id)
+                    self._pending.discard(entity_id)
+                    self._cleanup_if_done()
+            del bulk  # released before the next batch is fetched
 
     @callback
     def _schedule_retries(self, grace: float) -> None:
@@ -740,8 +860,21 @@ class _RestoreJob:
         return run_patched
 
     async def _patch_all_pending(self, grace: float) -> int:
+        """Sweep every currently-pending entity once.
+
+        Snapshots _pending up front since entries are removed while this
+        loop runs — but the persistent listener's batched drain
+        (_drain_pending_recovery_burst) can also resolve and discard
+        entities concurrently (this coroutine yields control at every
+        await, including inside _patch_pending itself). Re-checking
+        membership right before each call — not just once at snapshot time
+        — skips entities a concurrent drain already resolved instead of
+        issuing a redundant recorder query for them.
+        """
         run_patched = 0
         for entity_id in list(self._pending):
+            if entity_id not in self._pending:
+                continue
             if await self._patch_pending(entity_id, grace):
                 run_patched += 1
         self.stats["patched_total"] = (
@@ -1027,6 +1160,19 @@ class _RestoreJob:
         A failed batch yields an empty result but still yields its chunk, so
         those entities fall back to the snapshot/per-entity path in
         `_resolve` exactly as before instead of being skipped.
+
+        The trailing `asyncio.sleep(0)` after each batch paces the stream:
+        on a large "track all entities" install this loop can run for many
+        batches back to back, each one a synchronous query on the
+        recorder's own single-worker executor — without a yield point here,
+        our own coroutine is immediately ready again the instant one batch's
+        executor job resolves, which can keep crowding out other ready
+        callbacks on the main event loop for the whole pass. `sleep(0)` is a
+        pure yield with no added delay (unlike `sleep(n>0)`), so pacing this
+        way costs nothing in wall-clock time — it only gives other
+        already-ready work a fair turn between batches, shared by every
+        caller of this generator (the boot pass, verify, and the
+        re-registration/pending-recovery burst drains alike).
         """
         start = dt_util.utcnow() - timedelta(days=BULK_WINDOW_DAYS)
         batch_size = self._bulk_batch_size
@@ -1044,6 +1190,7 @@ class _RestoreJob:
                 result = {}
             yield chunk, result
             result = {}
+            await asyncio.sleep(0)
 
     # ----- Applying ------------------------------------------------------
 
@@ -1128,22 +1275,43 @@ class _RestoreJob:
     @callback
     def _setup_reregister_listener(self, targets: set[str]) -> None:
         """Persistent listener (entry lifetime, not just the boot pass) for
-        an already-watched entity being fully re-created (old_state is
-        None) after boot — e.g. its owning config entry reloads, or a
-        Zigbee/Z-Wave device rejoins — which resets last_changed to "now"
-        the same way a full HA restart does. Registered after boot has
-        already assigned every entity its initial state, so it never fires
-        for that initial assignment."""
+        an already-watched entity's last_changed getting reset to "now" by
+        something other than a full HA restart: either the entity being
+        fully re-created (old_state is None) — e.g. its owning config entry
+        reloads, or a Zigbee/Z-Wave device rejoins — or the entity recovering
+        from unavailable/unknown to a real value (a brief network/mesh
+        blip). HA's own state machine treats unavailable/unknown as a
+        distinct value, so recovering from it genuinely bumps last_changed
+        the same way a restart does, but unlike a restart nothing else in
+        this integration ever revisits that entity afterwards - the boot
+        pass only runs once at startup, and this was previously the only
+        listener, gated to old_state is None only. Left uncorrected, an
+        entity that flaps unavailable periodically during normal runtime
+        (common for Zigbee/Z-Wave/network devices) drifts wrong forever,
+        self-healing only at the next full restart. Registered after boot
+        has already assigned every entity its initial state, so it never
+        fires for that initial assignment."""
         self._unsub_reregister_listener = async_track_state_change_event(
             self.hass, list(targets), self._on_entity_reregistered
         )
 
     @callback
     def _on_entity_reregistered(self, event: Event) -> None:
-        if event.data.get("old_state") is not None:
-            return  # not a full re-registration
+        """Queue a fresh re-registration or unavailable-recovery for the
+        batched drain below instead of firing an immediate per-entity task:
+        a mass event (a hub's config entry reloading with hundreds of
+        entities, a Zigbee/Z-Wave coordinator coming back after an outage)
+        fires one such event per entity, and reacting to each with its own
+        recorder query is a thundering herd on the recorder executor. See
+        _drain_reregister_burst for the batched query itself.
+        """
+        old = event.data.get("old_state")
         new = event.data.get("new_state")
         if new is None or new.state in INVALID_STATES:
+            return
+        is_reregistration = old is None
+        is_unavailable_recovery = old is not None and old.state in INVALID_STATES
+        if not (is_reregistration or is_unavailable_recovery):
             return
         entity_id = new.entity_id
         if entity_id in self._pending:
@@ -1151,38 +1319,106 @@ class _RestoreJob:
         _, _, _, grace, _, _ = self._config
         if (dt_util.utcnow() - new.last_changed).total_seconds() > grace:
             return
-        self.hass.async_create_task(self._patch_reregistered(entity_id, grace))
-
-    async def _patch_reregistered(self, entity_id: str, grace: float) -> bool:
-        """Entry point for a fresh re-registration event: drops any retries
-        still scheduled from a previous flap of the same entity, makes one
-        attempt right away, and — only here — arms the retry ladder if that
-        attempt resolved nothing.
-
-        Arming the ladder exclusively at this single entry point is what
-        bounds the retry count: the timers themselves run
-        _attempt_reregister_patch, which never schedules, so one
-        re-registration can only ever produce len(retry_delays) retries.
-        """
+        # Drop any retry ladder still armed from a previous flap of this
+        # entity right away, rather than waiting for the drain — a stale
+        # timer must not fire mid-debounce-window against an entity that's
+        # about to be re-patched anyway.
         self._cancel_reregister_retry(entity_id)
-        result = await self._attempt_reregister_patch(entity_id, grace)
-        if result is _RETRY_WORTHWHILE:
-            self._schedule_reregister_retries(entity_id, grace)
-        return result is True
+        # Mark unconfirmed immediately, not just on a failed drain attempt:
+        # live.last_changed is the raw reset artifact for as long as this
+        # entity sits in the debounce window, and a snapshot write racing in
+        # during that window (e.g. HA shutting down mid-debounce) must not
+        # persist it as if it were real. _apply() clears this on success.
+        self._unconfirmed.add(entity_id)
+        self._reregister_burst.add(entity_id)
+        now = dt_util.utcnow()
+        if self._reregister_burst_since is None:
+            self._reregister_burst_since = now
+        self._cancel_reregister_flush_timer()
+        elapsed = (now - self._reregister_burst_since).total_seconds()
+        if elapsed >= REREGISTER_MAX_WAIT_SECONDS:
+            self._flush_reregister_burst()
+        else:
+            self._reregister_flush_timer = async_call_later(
+                self.hass, REREGISTER_DEBOUNCE_SECONDS, self._flush_reregister_burst
+            )
+
+    @callback
+    def _flush_reregister_burst(self, _now: datetime | None = None) -> None:
+        self._cancel_reregister_flush_timer()
+        self._reregister_burst_since = None
+        if not self._reregister_burst:
+            return
+        burst, self._reregister_burst = self._reregister_burst, set()
+        self.hass.async_create_task(self._drain_reregister_burst(burst))
+
+    async def _drain_reregister_burst(self, entity_ids: set[str]) -> None:
+        """Batched replacement for one recorder query per re-registered
+        entity: resolves the whole debounced burst together through the same
+        streaming bulk-query machinery the boot pass uses
+        (_iter_bulk_batches), so a mass re-registration costs a handful of
+        batched queries instead of one targeted query per entity.
+
+        Mirrors _async_run_impl's candidate/re-validate loop rather than
+        reusing _attempt_reregister_patch, since that helper always queries
+        one entity at a time (it also serves the retry ladder below, where
+        that is the right shape — retries are already spread across
+        RETRY_DELAYS, not bursty). Entities that don't resolve here still get
+        the same retry ladder as before.
+        """
+        _, _, _, grace, _, _ = self._config
+        candidates: list[str] = []
+        candidate_last_changed: dict[str, datetime] = {}
+        for entity_id in entity_ids:
+            live = self.hass.states.get(entity_id)
+            if live is None or live.state in INVALID_STATES:
+                continue
+            if (dt_util.utcnow() - live.last_changed).total_seconds() > grace:
+                continue
+            candidates.append(entity_id)
+            candidate_last_changed[entity_id] = live.last_changed
+
+        async for chunk, bulk in self._iter_bulk_batches(candidates):
+            for entity_id in chunk:
+                # Re-validate against the snapshot taken above: the bulk
+                # query just awaited the recorder executor, during which the
+                # entity may have gone unavailable or genuinely changed for
+                # real — see the matching comment in _async_run_impl.
+                live = self.hass.states.get(entity_id)
+                if live is None or live.state in INVALID_STATES:
+                    continue
+                if live.last_changed != candidate_last_changed[entity_id]:
+                    self._unconfirmed.discard(entity_id)
+                    continue
+                await self._maybe_restore_last_triggered(entity_id)
+                ts = await self._resolve(entity_id, live, bulk.get(entity_id))
+                if ts is not None:
+                    self._apply(live, ts, entity_id)
+                    _LOGGER.debug(
+                        "%s: re-patched after runtime re-registration", entity_id
+                    )
+                else:
+                    # Unresolved: live.last_changed is still this
+                    # re-registration's raw reset value — see _unconfirmed.
+                    self._unconfirmed.add(entity_id)
+                    self._schedule_reregister_retries(entity_id, grace)
+            del bulk  # released before the next batch is fetched
 
     async def _attempt_reregister_patch(
         self, entity_id: str, grace: float
     ) -> bool | None:
         """One targeted, per-entity re-patch attempt (no bulk query — this
-        is for a single entity, not a full boot pass). Also attempts the
+        is for a single entity, not a full burst drain). Also attempts the
         last_triggered path. Respects the same grace window as the boot pass.
 
         Deliberately free of scheduling side effects: it must never arm
-        retries itself. It runs both as the first attempt (from
-        _patch_reregistered) and as *every* retry attempt, so scheduling
-        here would let each failing retry arm a fresh ladder — the number of
-        attempts would then grow by a factor of len(retry_delays) per round
-        instead of being capped at one ladder per re-registration.
+        retries itself. It runs as every retry-ladder attempt (see
+        _retry_reregister), so scheduling here would let each failing retry
+        arm a fresh ladder — the number of attempts would then grow by a
+        factor of len(retry_delays) per round instead of being capped at one
+        ladder per re-registration. (The initial attempt, by contrast, goes
+        through the batched _drain_reregister_burst above, which arms the
+        ladder itself exactly once per unresolved entity.)
 
         Returns True when patched, False (_RETRY_WORTHWHILE) when the entity
         is a valid candidate that simply could not be resolved right now, and
@@ -1272,9 +1508,12 @@ class _RestoreJob:
         whole store on every single change (see async_write_snapshot).
 
         Restricted to genuine value transitions (old_state present and
-        actually different) — re-registrations (old_state is None, handled
-        by the re-registration listener above) and attribute-only "chatter"
-        (same state value, e.g. climate current_temperature) are ignored, so
+        actually different) — re-registrations (old_state is None) and
+        recoveries from unavailable/unknown (old_state.state in
+        INVALID_STATES) are both handled by the re-registration listener
+        above instead, since HA resets last_changed to "now" for those too
+        without the value having genuinely changed; attribute-only "chatter"
+        (same state value, e.g. climate current_temperature) is ignored so
         one noisy entity can't perpetually starve the debounce for others.
         """
         old = event.data.get("old_state")
@@ -1283,6 +1522,8 @@ class _RestoreJob:
             return
         if new.state in INVALID_STATES or old.state == new.state:
             return
+        if old.state in INVALID_STATES:
+            return  # recovery from unavailable/unknown, not a genuine change
         self._unconfirmed.discard(new.entity_id)
         self._dirty[new.entity_id] = {
             "s": new.state,

--- a/custom_components/last_changed_keeper/const.py
+++ b/custom_components/last_changed_keeper/const.py
@@ -44,6 +44,39 @@ INCREMENTAL_DEBOUNCE_SECONDS = 8
 # fully starve the incremental store.
 INCREMENTAL_MAX_WAIT_SECONDS = 30
 
+# Debounce for the re-registration burst drain (see _on_entity_reregistered /
+# _drain_reregister_burst): a mass re-registration (a hub's config entry
+# reloading with hundreds of entities, a Zigbee/Z-Wave coordinator coming
+# back after an outage) fires one state-changed event per entity, spread
+# across a short window rather than all in the same tick. Coalescing them
+# into a single batched drain caps recorder load at a handful of bulk
+# queries instead of one targeted query per entity. Short relative to
+# INCREMENTAL_DEBOUNCE_SECONDS since a lone re-registration (the common
+# case) should still feel close to immediate.
+REREGISTER_DEBOUNCE_SECONDS = 2
+# Hard upper bound on how long a continuously-arriving burst can push the
+# debounce back before it is drained anyway, for the same reason
+# INCREMENTAL_MAX_WAIT_SECONDS exists: a coordinator that keeps registering
+# new entities for a while must not starve the drain of all of them
+# indefinitely.
+REREGISTER_MAX_WAIT_SECONDS = 10
+
+# Debounce for the boot-pending recovery burst drain (see
+# _on_pending_entity_recovered / _drain_pending_recovery_burst): a mass
+# unavailable-to-real transition early in boot (a Zigbee/Z-Wave mesh
+# finishing formation and announcing many devices within the same few
+# seconds) fires one state-changed event per entity, and reacting to each
+# with its own recorder query is the same thundering-herd risk
+# REREGISTER_DEBOUNCE_SECONDS guards against, just at boot instead of
+# during normal runtime. Kept as its own constant (same value) rather than
+# reusing REREGISTER_DEBOUNCE_SECONDS so the two can be tuned independently
+# if one ever needs to change without affecting the other.
+PENDING_RECOVERY_DEBOUNCE_SECONDS = 2
+# Hard upper bound on how long a continuously-arriving boot recovery burst
+# can push the debounce back before it is drained anyway, for the same
+# reason REREGISTER_MAX_WAIT_SECONDS exists.
+PENDING_RECOVERY_MAX_WAIT_SECONDS = 10
+
 EVENT_RESTORED = f"{DOMAIN}_restored"
 
 # Snapshot store (fallback when the recorder no longer has the entity).

--- a/custom_components/last_changed_keeper/manifest.json
+++ b/custom_components/last_changed_keeper/manifest.json
@@ -11,5 +11,5 @@
   "loggers": ["custom_components.last_changed_keeper"],
   "quality_scale": "gold",
   "single_config_entry": true,
-  "version": "0.9.5"
+  "version": "0.9.6"
 }

--- a/tests/test_bulk_batching.py
+++ b/tests/test_bulk_batching.py
@@ -164,6 +164,37 @@ async def test_bulk_batches_use_configured_batch_size(
     assert set(delivered) == set(ids)
 
 
+async def test_iter_bulk_batches_paces_with_a_zero_delay_sleep_between_batches(
+    recorder_mock, hass: HomeAssistant, monkeypatch
+) -> None:
+    """Regression (P4.1): a long streamed pass over many batches must yield
+    to the event loop between them - via a zero-delay asyncio.sleep(0), not
+    a real delay - instead of immediately queuing the next batch's recorder
+    executor job, so other pending work gets a fair turn."""
+    monkeypatch.setattr(lck, "_bulk_query", lambda _h, _s, ids: {i: [] for i in ids})
+    monkeypatch.setattr(lck, "BULK_BATCH_SIZE", 2)
+
+    sleeps: list[float] = []
+    original_sleep = lck.asyncio.sleep
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+        await original_sleep(0)
+
+    monkeypatch.setattr(lck.asyncio, "sleep", fake_sleep)
+
+    job = _make_job(hass)
+    ids = [f"light.l{i}" for i in range(5)]
+    batch_count = 0
+    async for _chunk, _result in job._iter_bulk_batches(ids):
+        batch_count += 1
+
+    assert batch_count == 3  # 2 + 2 + 1, matching BULK_BATCH_SIZE
+    # One pacing yield per batch, all zero-delay - a long pass costs nothing
+    # extra in wall-clock time.
+    assert sleeps == [0] * batch_count
+
+
 async def test_bulk_batch_size_falls_back_to_default_when_invalid(
     recorder_mock, hass: HomeAssistant
 ) -> None:

--- a/tests/test_incremental_store.py
+++ b/tests/test_incremental_store.py
@@ -128,6 +128,36 @@ async def test_reregistration_event_not_merged_into_incremental_store(
     assert STORAGE_KEY not in hass_storage
 
 
+async def test_unavailable_recovery_not_merged_into_incremental_store(
+    recorder_mock, enable_custom_integrations, hass: HomeAssistant, hass_storage
+) -> None:
+    """Regression: recovering from unavailable/unknown resets last_changed
+    to "now" the same way a re-registration does (HA treats unavailable as
+    a distinct value), so it must be excluded here too - merging it would
+    write the raw reset artifact into the snapshot store as if it were a
+    real value change, poisoning it for the next boot. It's the
+    re-registration listener's job instead (see test_reregistration.py)."""
+    hass.states.async_set("light.kitchen", "on")
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_DOMAINS: ["light"], CONF_ENTITIES: []}
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    hass.states.async_set("light.kitchen", "unavailable")
+    await hass.async_block_till_done()
+    hass.states.async_set("light.kitchen", "on")
+    await hass.async_block_till_done()
+
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + timedelta(seconds=INCREMENTAL_DEBOUNCE_SECONDS + 1)
+    )
+    await hass.async_block_till_done()
+
+    assert STORAGE_KEY not in hass_storage
+
+
 async def test_unload_cancels_incremental_listener_and_flush_timer(
     recorder_mock, enable_custom_integrations, hass: HomeAssistant
 ) -> None:

--- a/tests/test_pending_recovery_burst.py
+++ b/tests/test_pending_recovery_burst.py
@@ -1,0 +1,137 @@
+"""Tests for the boot-pending recovery burst: entities that were pending at
+boot (unavailable/unknown when the boot pass ran) get a second chance via a
+persistent listener for their unavailable→real transition. Individual
+transitions are debounce-coalesced into a burst set and drained together
+(see _drain_pending_recovery_burst) instead of firing one recorder query per
+entity, the same treatment P3.1 gave the re-registration listener.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
+
+from custom_components.last_changed_keeper import _RestoreJob
+from custom_components.last_changed_keeper.const import (
+    DOMAIN,
+    PENDING_RECOVERY_DEBOUNCE_SECONDS,
+    STORAGE_KEY,
+    STORAGE_VERSION,
+)
+
+
+def _make_job(hass: HomeAssistant, snapshot: dict | None = None) -> _RestoreJob:
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    store = Store(hass, STORAGE_VERSION, STORAGE_KEY)
+    return _RestoreJob(hass, entry, store, snapshot or {})
+
+
+async def _flush_pending_recovery_burst(hass: HomeAssistant) -> None:
+    async_fire_time_changed(
+        hass,
+        dt_util.utcnow() + timedelta(seconds=PENDING_RECOVERY_DEBOUNCE_SECONDS + 1),
+    )
+    await hass.async_block_till_done()
+
+
+async def test_pending_recovery_burst_is_coalesced_into_one_batched_drain(
+    recorder_mock, hass: HomeAssistant, monkeypatch
+) -> None:
+    """Regression: several boot-pending entities recovering from unavailable
+    close together must be coalesced into a single batched drain instead of
+    one recorder query per entity."""
+    import custom_components.last_changed_keeper as lck
+
+    entity_ids = [f"light.bulb_{i}" for i in range(5)]
+    for entity_id in entity_ids:
+        hass.states.async_set(entity_id, "unavailable")
+    await hass.async_block_till_done()
+
+    job = _make_job(hass)
+    await job.async_run()
+    await hass.async_block_till_done()
+    assert job._pending == set(entity_ids)
+
+    calls: list[list[str]] = []
+
+    def fake_bulk_query(_hass, _start, chunk):
+        calls.append(list(chunk))
+        return {}
+
+    monkeypatch.setattr(lck, "_bulk_query", fake_bulk_query)
+
+    for entity_id in entity_ids:
+        hass.states.async_set(entity_id, "on")
+        await hass.async_block_till_done()
+
+    # All five recovered within the debounce window -> queued together, not
+    # yet drained (and no recorder query issued yet).
+    assert job._pending_recovery_burst == set(entity_ids)
+    assert calls == []
+
+    await _flush_pending_recovery_burst(hass)
+
+    # One batched recorder query covering every entity in the burst, not
+    # five separate ones.
+    assert len(calls) == 1
+    assert sorted(calls[0]) == sorted(entity_ids)
+    assert job._pending_recovery_burst == set()
+
+    # None of them were resolvable (fake query returns nothing, no
+    # snapshot) -> they stay pending for the scheduled retry pass, same as
+    # an unresolvable boot candidate always has.
+    assert job._pending == set(entity_ids)
+
+
+async def test_unresolved_pending_recovery_stays_pending_for_retry_pass(
+    recorder_mock, hass: HomeAssistant
+) -> None:
+    """Unlike the re-registration burst, there is no per-entity retry ladder
+    here - an entity the drain can't resolve simply stays in _pending for
+    the existing scheduled retry passes to pick up later."""
+    hass.states.async_set("light.slow_zigbee", "unavailable")
+    await hass.async_block_till_done()
+
+    job = _make_job(hass)
+    await job.async_run()
+    await hass.async_block_till_done()
+    assert "light.slow_zigbee" in job._pending
+
+    hass.states.async_set("light.slow_zigbee", "on")
+    await hass.async_block_till_done()
+    await _flush_pending_recovery_burst(hass)
+
+    # Nothing resolvable (no recorder history, no snapshot) -> still pending,
+    # and the persistent listener/timers are still armed for the next event
+    # or scheduled retry.
+    assert "light.slow_zigbee" in job._pending
+    assert job._unsub_listener is not None
+
+
+async def test_pending_recovery_resolves_from_snapshot(
+    recorder_mock, hass: HomeAssistant
+) -> None:
+    stale = dt_util.utcnow() - timedelta(days=3)
+    hass.states.async_set("light.slow_zigbee", "unavailable")
+    await hass.async_block_till_done()
+
+    job = _make_job(
+        hass, snapshot={"light.slow_zigbee": {"s": "on", "t": stale.isoformat()}}
+    )
+    await job.async_run()
+    await hass.async_block_till_done()
+    assert "light.slow_zigbee" in job._pending
+
+    hass.states.async_set("light.slow_zigbee", "on")
+    await hass.async_block_till_done()
+    await _flush_pending_recovery_burst(hass)
+
+    live = hass.states.get("light.slow_zigbee")
+    assert live.last_changed == stale
+    assert "light.slow_zigbee" not in job._pending

--- a/tests/test_reregistration.py
+++ b/tests/test_reregistration.py
@@ -1,9 +1,11 @@
-"""Tests for the runtime re-registration path: an already-watched entity
-that gets fully re-created (e.g. its owning config entry reloads, or a
-Zigbee/Z-Wave device rejoins) resets last_changed to "now" the same way a
-full HA restart does. A persistent, entry-lifetime listener (independent of
-the boot-time pending/listener machinery) catches this and re-patches just
-that one entity, respecting the same grace window and retry_delays.
+"""Tests for the runtime re-registration / unavailable-recovery path: an
+already-watched entity that gets fully re-created (e.g. its owning config
+entry reloads, or a Zigbee/Z-Wave device rejoins), or that merely recovers
+from unavailable/unknown to a real value during normal runtime (a brief
+network/mesh blip), resets last_changed to "now" the same way a full HA
+restart does. A persistent, entry-lifetime listener (independent of the
+boot-time pending/listener machinery) catches both cases and re-patches the
+entity, respecting the same grace window and retry_delays.
 """
 from __future__ import annotations
 
@@ -21,9 +23,19 @@ from custom_components.last_changed_keeper.const import (
     CONF_DOMAINS,
     CONF_ENTITIES,
     DOMAIN,
+    REREGISTER_DEBOUNCE_SECONDS,
     RETRY_DELAYS,
     STORAGE_KEY,
 )
+
+
+async def _flush_reregister_burst(hass: HomeAssistant) -> None:
+    """Advance past the re-registration debounce so the batched drain (see
+    _drain_reregister_burst) runs, then let its recorder query settle."""
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + timedelta(seconds=REREGISTER_DEBOUNCE_SECONDS + 1)
+    )
+    await hass.async_block_till_done()
 
 
 async def _add_entry(hass: HomeAssistant) -> MockConfigEntry:
@@ -61,6 +73,7 @@ async def test_reregistration_patches_from_snapshot(
     await hass.async_block_till_done()
     hass.states.async_set("light.kitchen", "on")
     await hass.async_block_till_done()
+    await _flush_reregister_burst(hass)
 
     live = hass.states.get("light.kitchen")
     assert live.last_changed == stale
@@ -97,6 +110,110 @@ async def test_reregistration_ignored_when_grace_exceeded(
     assert live.last_changed == old_ts  # untouched: already older than grace
 
 
+# ----- Recovery from unavailable/unknown ------------------------------------
+
+
+async def test_unavailable_recovery_patches_from_snapshot(
+    recorder_mock, enable_custom_integrations, hass: HomeAssistant, hass_storage
+) -> None:
+    """A device that flaps unavailable and recovers to the same value during
+    normal runtime (not a restart, not a full re-registration) resets
+    last_changed the same way HA treats any other value change - this must
+    be caught and re-patched exactly like a re-registration is."""
+    stale = dt_util.utcnow() - timedelta(days=2)
+    hass_storage[STORAGE_KEY] = {
+        "version": 1,
+        "minor_version": 1,
+        "key": STORAGE_KEY,
+        "data": {"light.kitchen": {"s": "on", "t": stale.isoformat()}},
+    }
+    hass.states.async_set("light.kitchen", "on")
+    await _add_entry(hass)
+
+    # Simulate a brief network/mesh blip: the entity goes unavailable and
+    # recovers to the SAME real value, without ever being fully removed.
+    hass.states.async_set("light.kitchen", "unavailable")
+    await hass.async_block_till_done()
+    hass.states.async_set("light.kitchen", "on")
+    await hass.async_block_till_done()
+    await _flush_reregister_burst(hass)
+
+    live = hass.states.get("light.kitchen")
+    assert live.last_changed == stale
+
+
+async def test_unavailable_recovery_ignored_when_grace_exceeded(
+    recorder_mock, enable_custom_integrations, hass: HomeAssistant, hass_storage
+) -> None:
+    stale = dt_util.utcnow() - timedelta(days=2)
+    hass_storage[STORAGE_KEY] = {
+        "version": 1,
+        "minor_version": 1,
+        "key": STORAGE_KEY,
+        "data": {"light.kitchen": {"s": "on", "t": stale.isoformat()}},
+    }
+    hass.states.async_set("light.kitchen", "on")
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_DOMAINS: ["light"], CONF_ENTITIES: [], "grace_seconds": 60},
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    hass.states.async_set("light.kitchen", "unavailable")
+    await hass.async_block_till_done()
+    old_ts = dt_util.utcnow() - timedelta(seconds=120)
+    hass.states.async_set("light.kitchen", "on", timestamp=old_ts.timestamp())
+    await hass.async_block_till_done()
+
+    live = hass.states.get("light.kitchen")
+    assert live.last_changed == old_ts  # untouched: already older than grace
+
+
+async def test_unknown_recovery_also_triggers_repatch(
+    recorder_mock, enable_custom_integrations, hass: HomeAssistant, hass_storage
+) -> None:
+    """unknown is treated the same as unavailable - both are INVALID_STATES,
+    not just the more common of the two."""
+    stale = dt_util.utcnow() - timedelta(days=2)
+    hass_storage[STORAGE_KEY] = {
+        "version": 1,
+        "minor_version": 1,
+        "key": STORAGE_KEY,
+        "data": {"light.kitchen": {"s": "on", "t": stale.isoformat()}},
+    }
+    hass.states.async_set("light.kitchen", "on")
+    await _add_entry(hass)
+
+    hass.states.async_set("light.kitchen", "unknown")
+    await hass.async_block_till_done()
+    hass.states.async_set("light.kitchen", "on")
+    await hass.async_block_till_done()
+    await _flush_reregister_burst(hass)
+
+    live = hass.states.get("light.kitchen")
+    assert live.last_changed == stale
+
+
+async def test_genuine_value_change_does_not_enter_reregister_burst(
+    recorder_mock, enable_custom_integrations, hass: HomeAssistant
+) -> None:
+    """Regression: an ordinary value change (old_state present and valid,
+    genuinely different from new_state) must go through the incremental
+    listener, not the re-registration/recovery burst - it's real
+    information, not a reset artifact."""
+    hass.states.async_set("light.kitchen", "off")
+    entry = await _add_entry(hass)
+    job = entry.runtime_data
+
+    hass.states.async_set("light.kitchen", "on")
+    await hass.async_block_till_done()
+
+    assert job._reregister_burst == set()
+    assert job._reregister_flush_timer is None
+
+
 async def test_reregistration_retries_when_not_immediately_resolvable(
     recorder_mock, enable_custom_integrations, hass: HomeAssistant
 ) -> None:
@@ -108,6 +225,7 @@ async def test_reregistration_retries_when_not_immediately_resolvable(
     await hass.async_block_till_done()
     hass.states.async_set("light.kitchen", "on")
     await hass.async_block_till_done()
+    await _flush_reregister_burst(hass)
 
     # Nothing resolvable yet (no recorder history, no snapshot) -> retry
     # timers scheduled for this entity instead of giving up immediately.
@@ -156,8 +274,10 @@ async def test_reregistration_retry_ladder_does_not_grow_on_repeated_failure(
     await hass.async_block_till_done()
     hass.states.async_set("light.kitchen", "on")
     await hass.async_block_till_done()
+    await _flush_reregister_burst(hass)
 
-    # Nothing resolvable -> the first attempt failed and armed one ladder.
+    # Nothing resolvable -> the first attempt (via the batched drain, not
+    # _attempt_reregister_patch - see below) failed and armed one ladder.
     assert len(job._reregister_retry_timers["light.kitchen"]) == len(RETRY_DELAYS)
 
     # Drive every rung while the entity stays unresolvable. The ladder must
@@ -169,8 +289,11 @@ async def test_reregistration_retry_ladder_does_not_grow_on_repeated_failure(
         armed = job._reregister_retry_timers.get("light.kitchen", [])
         assert len(armed) <= len(RETRY_DELAYS)
 
-    # Exactly one initial attempt plus one per retry delay - not a multiple.
-    assert len(attempts) == 1 + len(RETRY_DELAYS)
+    # One attempt per retry delay - not a multiple. The initial attempt goes
+    # through the batched drain (_drain_reregister_burst), which calls
+    # _resolve directly rather than _attempt_reregister_patch, so it isn't
+    # counted here - only the retry ladder is.
+    assert len(attempts) == len(RETRY_DELAYS)
     # Ladder exhausted: the entry is pruned rather than left behind holding
     # already-fired timers (one stale entry per entity, forever, otherwise).
     assert "light.kitchen" not in job._reregister_retry_timers
@@ -220,6 +343,7 @@ async def test_successful_retry_cancels_the_rest_of_the_ladder(
     await hass.async_block_till_done()
     hass.states.async_set("light.kitchen", "on")
     await hass.async_block_till_done()
+    await _flush_reregister_burst(hass)
     assert len(job._reregister_retry_timers["light.kitchen"]) == len(RETRY_DELAYS)
 
     stale = dt_util.utcnow() - timedelta(days=1)
@@ -248,6 +372,7 @@ async def test_new_reregistration_replaces_armed_ladder(
         await hass.async_block_till_done()
         hass.states.async_set("light.kitchen", "on")
         await hass.async_block_till_done()
+        await _flush_reregister_burst(hass)
         assert len(job._reregister_retry_timers["light.kitchen"]) == len(RETRY_DELAYS)
 
 
@@ -281,6 +406,7 @@ async def test_unload_cancels_reregister_listener_and_retries(
     await hass.async_block_till_done()
     hass.states.async_set("light.kitchen", "on")
     await hass.async_block_till_done()
+    await _flush_reregister_burst(hass)
     assert "light.kitchen" in job._reregister_retry_timers
 
     assert await hass.config_entries.async_unload(entry.entry_id)
@@ -288,6 +414,109 @@ async def test_unload_cancels_reregister_listener_and_retries(
 
     assert job._unsub_reregister_listener is None
     assert job._reregister_retry_timers == {}
+
+
+async def test_unload_cancels_pending_reregister_burst(
+    recorder_mock, enable_custom_integrations, hass: HomeAssistant
+) -> None:
+    """A re-registration still sitting in the debounce window at unload
+    time must not fire its drain afterwards against a torn-down job."""
+    hass.states.async_set("light.kitchen", "on")
+    entry = await _add_entry(hass)
+    job = entry.runtime_data
+
+    hass.states.async_remove("light.kitchen")
+    await hass.async_block_till_done()
+    hass.states.async_set("light.kitchen", "on")
+    await hass.async_block_till_done()
+    assert "light.kitchen" in job._reregister_burst
+    assert job._reregister_flush_timer is not None
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert job._reregister_burst == set()
+    assert job._reregister_flush_timer is None
+
+    # The timer that would have flushed the burst must be well and truly
+    # cancelled, not just forgotten about - fire time forward past it and
+    # confirm nothing blows up trying to act on a torn-down job.
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + timedelta(seconds=REREGISTER_DEBOUNCE_SECONDS + 1)
+    )
+    await hass.async_block_till_done()
+
+
+async def test_reregistration_burst_is_coalesced_into_one_batched_drain(
+    recorder_mock, enable_custom_integrations, hass: HomeAssistant, monkeypatch
+) -> None:
+    """Regression: a burst of re-registrations arriving close together (a
+    hub's config entry reloading with several entities at once) must be
+    coalesced into a single batched drain instead of firing one recorder
+    query per entity - see _drain_reregister_burst.
+    """
+    import custom_components.last_changed_keeper as lck
+
+    entity_ids = [f"light.bulb_{i}" for i in range(5)]
+    for entity_id in entity_ids:
+        hass.states.async_set(entity_id, "on")
+    entry = await _add_entry(hass)
+    job = entry.runtime_data
+
+    calls: list[list[str]] = []
+
+    def fake_bulk_query(_hass, _start, chunk):
+        calls.append(list(chunk))
+        return {}
+
+    monkeypatch.setattr(lck, "_bulk_query", fake_bulk_query)
+
+    for entity_id in entity_ids:
+        hass.states.async_remove(entity_id)
+        await hass.async_block_till_done()
+        hass.states.async_set(entity_id, "on")
+        await hass.async_block_till_done()
+
+    # All five re-registered within the debounce window -> queued together,
+    # not yet drained (and no recorder query issued yet).
+    assert job._reregister_burst == set(entity_ids)
+    assert calls == []
+
+    await _flush_reregister_burst(hass)
+
+    # One batched recorder query covering every entity in the burst, not
+    # five separate ones.
+    assert len(calls) == 1
+    assert sorted(calls[0]) == sorted(entity_ids)
+    assert job._reregister_burst == set()
+
+    # None of them were resolvable (fake query returns nothing, no
+    # snapshot) -> each still gets its own retry ladder, same as before.
+    for entity_id in entity_ids:
+        assert entity_id in job._reregister_retry_timers
+
+
+async def test_entity_marked_unconfirmed_immediately_on_queueing(
+    recorder_mock, enable_custom_integrations, hass: HomeAssistant
+) -> None:
+    """Regression: an entity must be _unconfirmed for the entire debounce
+    window, not just after a failed drain attempt - otherwise a snapshot
+    write racing in before the drain runs (e.g. HA shutting down
+    mid-debounce) would persist the raw reset artifact as if it were real.
+    """
+    hass.states.async_set("light.kitchen", "on")
+    entry = await _add_entry(hass)
+    job = entry.runtime_data
+
+    hass.states.async_remove("light.kitchen")
+    await hass.async_block_till_done()
+    hass.states.async_set("light.kitchen", "on")
+    await hass.async_block_till_done()
+
+    # Still inside the debounce window - not drained yet, but already
+    # unconfirmed.
+    assert "light.kitchen" in job._reregister_burst
+    assert "light.kitchen" in job._unconfirmed
 
 
 async def test_cleanup_if_done_does_not_tear_down_reregister_listener(

--- a/tests/test_restore_job_lifecycle.py
+++ b/tests/test_restore_job_lifecycle.py
@@ -1,5 +1,8 @@
 """Tests for _RestoreJob lifecycle behavior: the single_pass service call
-must not tear down an active boot-time retry/listener pass.
+must not tear down an active boot-time retry/listener pass, and
+_patch_all_pending's sweep of self._pending must stay correct when a
+concurrent burst drain (_drain_pending_recovery_burst) mutates the same set
+mid-sweep.
 """
 from __future__ import annotations
 
@@ -74,3 +77,39 @@ async def test_single_pass_patches_pending_entity_that_recovered(
     assert "light.slow_zigbee" not in job._pending
     # pending is now empty -> _cleanup_if_done() legitimately tore it down.
     assert torn_down == ["listener"]
+
+
+async def test_patch_all_pending_skips_entity_resolved_concurrently(
+    recorder_mock, hass: HomeAssistant, monkeypatch
+) -> None:
+    """Regression: _patch_all_pending snapshots _pending at loop start, but
+    the persistent listener's batched drain (_drain_pending_recovery_burst)
+    can resolve and discard an entity from that same set while this loop is
+    still working through its snapshot (this coroutine yields control at
+    every await, including inside _patch_pending). The loop must re-check
+    membership before each call instead of blindly working through the
+    stale snapshot, or it issues a redundant recorder query for an entity a
+    concurrent drain already resolved."""
+    hass.states.async_set("light.a", "on")
+    hass.states.async_set("light.b", "on")
+    job = _make_job(hass)
+    job._pending = {"light.a", "light.b"}
+
+    calls: list[str] = []
+
+    async def fake_patch_pending(entity_id: str, grace: float) -> bool:
+        calls.append(entity_id)
+        # Simulate a concurrent drain resolving the OTHER entity while this
+        # call is "in flight" - regardless of which entity is processed
+        # first, the other one vanishes from _pending mid-sweep.
+        other = "light.b" if entity_id == "light.a" else "light.a"
+        job._pending.discard(other)
+        return False
+
+    monkeypatch.setattr(job, "_patch_pending", fake_patch_pending)
+
+    await job._patch_all_pending(1800)
+
+    # Only the first entity was ever attempted - the second was skipped
+    # because it was no longer pending by the time the loop reached it.
+    assert calls == [calls[0]]

--- a/tests/test_restored_event.py
+++ b/tests/test_restored_event.py
@@ -9,12 +9,16 @@ from datetime import timedelta
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
 from homeassistant.util import dt as dt_util
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
 
 from custom_components.last_changed_keeper import _RestoreJob
 from custom_components.last_changed_keeper.const import (
     DOMAIN,
     EVENT_RESTORED,
+    PENDING_RECOVERY_DEBOUNCE_SECONDS,
     STORAGE_KEY,
     STORAGE_VERSION,
 )
@@ -64,8 +68,14 @@ async def test_fires_not_final_then_final_once_pending_drains(
     assert events[0]["final"] is False
     assert events[0]["pending"] == 1
 
-    # entity recovers -> listener patches it -> pending drains to zero
+    # entity recovers -> listener queues it for the debounced batched drain
+    # (see _drain_pending_recovery_burst) -> pending drains to zero
     hass.states.async_set("light.slow_zigbee", "on")
+    await hass.async_block_till_done()
+    async_fire_time_changed(
+        hass,
+        dt_util.utcnow() + timedelta(seconds=PENDING_RECOVERY_DEBOUNCE_SECONDS + 1),
+    )
     await hass.async_block_till_done()
 
     assert len(events) == 2


### PR DESCRIPTION
## Summary

Follow-up to 0.9.5's snapshot-poisoning fix. Continued exercising this
integration against the same real ~3,500-entity installation and found four
more issues, bundled into one release since three are variations on the
same shape (a listener firing one recorder query per entity instead of a
batched drain) and the fourth is a pacing follow-up to 0.9.4's bulk-query
rewrite.

## 1. Recovery from unavailable/unknown never got a second chance

HA's state machine treats `unavailable`/`unknown` as a distinct value, so an
entity recovering from it bumps `last_changed` the same way a restart does.
Unlike a restart, though, nothing else ever revisited that entity
afterwards — only full restarts and full re-registrations were handled.
Field-diagnosed via read-only queries against the installation's recorder
DB: **734 of 811** outstanding `verify` mismatches (90.5%, across 16
domains) traced to exactly this. An entity that flaps `unavailable`
periodically (common for exactly the class of device this bites — Zigbee/
Z-Wave, flaky network devices) drifted wrong forever, self-healing only at
the next full restart. The re-registration listener now also watches for
`old_state.state in INVALID_STATES`, not just `old_state is None`.

## 2. Per-entity queries on mass listener events

That re-registration listener, and the boot-time pending-recovery listener
(entities still `unavailable` when the boot pass ran), both spawned one
recorder query per entity as events arrived. A mass event — a hub's config
entry reloading with hundreds of entities, a Zigbee/Z-Wave mesh finishing
formation and announcing many devices within the same few seconds — fired a
thundering herd of targeted queries all at once. Both are now
debounce-coalesced into a batched drain that reuses the same streaming
bulk-query machinery as the boot pass, capping recorder load at a handful
of bulk queries instead of one per entity.

## 3. Stale-snapshot iteration in the retry sweep

The scheduled retry sweep of `self._pending` snapshotted the set once at
loop start, so a concurrent burst drain (from #2) resolving an entity
mid-sweep left the sweep still working from a stale snapshot. Not a
wrong-value bug — the resolve chain's existing bounded/margin guards
already prevent that — but a wasted, redundant recorder query for an
entity another coroutine had already resolved and discarded moments
earlier. The sweep now re-checks membership immediately before each call.

## 4. No yield point in the streamed bulk query

`_iter_bulk_batches` (shared by the boot pass, `verify`, and both burst
drains above) never yielded control between batches. A large "track all
entities" install can mean many batches back to back, each a synchronous
query on the recorder's own single-worker executor; without a yield point,
our own coroutine was immediately ready again the instant one batch
resolved, crowding out other ready callbacks on the main event loop for the
whole pass. Added a zero-delay `asyncio.sleep(0)` after each batch — costs
nothing in wall-clock time, just gives other already-ready work a fair
turn.

## Test plan

- [x] Full suite passes (150 tests)
- [x] `ruff check .` clean
- [x] Manually verified on the same live ~3,500-entity installation

Ported from field-tested, individually-reviewed fixes on that installation:
cerebrate/last_changed_keeper#8, #9, #10, #11, #12. See issue #1.